### PR TITLE
Updating controller with camecase and pascalcase namming

### DIFF
--- a/app/View/Components/Input.php
+++ b/app/View/Components/Input.php
@@ -4,7 +4,7 @@ namespace App\View\Components;
 
 use Illuminate\View\Component;
 
-class textarea_simple extends Component
+class Input extends Component
 {
     public $col;
     public $label;
@@ -40,8 +40,14 @@ class textarea_simple extends Component
 
     }
 
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\View\View|string
+     */
     public function render()
     {
-        return view('components.textarea_simple');
+        return view('components.input');
     }
+
 }

--- a/app/View/Components/Li.php
+++ b/app/View/Components/Li.php
@@ -5,7 +5,7 @@ namespace App\View\Components;
 use Illuminate\Support\Str;
 use Illuminate\View\Component;
 
-class li extends Component
+class Li extends Component
 {
     /**
      * Create a new component instance.

--- a/app/View/Components/Menu_developer.php
+++ b/app/View/Components/Menu_developer.php
@@ -4,7 +4,7 @@ namespace App\View\Components;
 
 use Illuminate\View\Component;
 
-class menu_developer extends Component
+class Menu_developer extends Component
 {
     /**
      * Create a new component instance.

--- a/app/View/Components/Menu_researcher.php
+++ b/app/View/Components/Menu_researcher.php
@@ -4,7 +4,7 @@ namespace App\View\Components;
 
 use Illuminate\View\Component;
 
-class menu_reviewer extends Component
+class Menu_researcher extends Component
 {
     /**
      * Create a new component instance.
@@ -23,6 +23,6 @@ class menu_reviewer extends Component
      */
     public function render()
     {
-        return view('components.menu_reviewer');
+        return view('components.menu_researcher');
     }
 }

--- a/app/View/Components/Menu_reviewer.php
+++ b/app/View/Components/Menu_reviewer.php
@@ -4,7 +4,7 @@ namespace App\View\Components;
 
 use Illuminate\View\Component;
 
-class menu_researcher extends Component
+class Menu_reviewer extends Component
 {
     /**
      * Create a new component instance.
@@ -23,6 +23,6 @@ class menu_researcher extends Component
      */
     public function render()
     {
-        return view('components.menu_researcher');
+        return view('components.menu_reviewer');
     }
 }

--- a/app/View/Components/Textarea.php
+++ b/app/View/Components/Textarea.php
@@ -4,7 +4,7 @@ namespace App\View\Components;
 
 use Illuminate\View\Component;
 
-class input extends Component
+class Textarea extends Component
 {
     public $col;
     public $label;
@@ -43,11 +43,10 @@ class input extends Component
     /**
      * Get the view / contents that represent the component.
      *
-     * @return \Illuminate\View\View|string
+     * @return \Illuminate\Contracts\View\View|\Closure|string
      */
     public function render()
     {
-        return view('components.input');
+        return view('components.textarea');
     }
-
 }

--- a/app/View/Components/Textarea_simple.php
+++ b/app/View/Components/Textarea_simple.php
@@ -4,7 +4,7 @@ namespace App\View\Components;
 
 use Illuminate\View\Component;
 
-class textarea extends Component
+class Textarea_simple extends Component
 {
     public $col;
     public $label;
@@ -40,13 +40,8 @@ class textarea extends Component
 
     }
 
-    /**
-     * Get the view / contents that represent the component.
-     *
-     * @return \Illuminate\Contracts\View\View|\Closure|string
-     */
     public function render()
     {
-        return view('components.textarea');
+        return view('components.textarea_simple');
     }
 }


### PR DESCRIPTION
The compiler was giving problems when coping with naming under case sensitive filesystems.
This was tested using a PopOs 20.04 distribution, vagrant 2.2.6 and Virtualbox 6.1. The errors we obtained were:
![image](https://user-images.githubusercontent.com/1789503/131862681-a2924761-cd74-44f7-be63-41315a8b8edd.png)



This follows the recommendation from https://stackoverflow.com/questions/65038599/class-does-not-comply-with-psr-4-autoloading-standard-skipping to rely on PSR-4 with composer adheres to. 

After the PR, you get the expected view:

![image](https://user-images.githubusercontent.com/1789503/131862969-7dafa949-7850-4860-bc78-f0dbc182cb01.png)


PS: PR to master as requested by the main developer @drorganvidez 